### PR TITLE
Chart improvements from SH

### DIFF
--- a/charts/nhi-scout/templates/_cronjob.tpl
+++ b/charts/nhi-scout/templates/_cronjob.tpl
@@ -23,8 +23,8 @@ spec:
           {{- include "nhi-scout.securityContext" $ | indent 10 }}
           containers:
             - name: {{ .Chart.Name }}
-              image: "{{ .Values.image.repository }}:{{ .Values.inventory.version }}"
-              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              image: {{ include "nhi-scout.image" . }}
+              imagePullPolicy: {{ .Values.imagePullPolicy }}
               {{- include "nhi-scout.containerSecurityContext" $ | indent 14 }}
               args:
                 - {{ .command }}
@@ -45,9 +45,7 @@ spec:
                 {{- range .Values.volumeMounts }}
                 - {{ toJson . }}
                 {{- end }}
-          {{- with .Values.imagePullSecrets }}
-          imagePullSecrets: {{ toJson . }}
-          {{- end }}
+          {{- include "nhi-scout.imagePullSecrets" . | indent 10 }}
           serviceAccountName: {{ include "nhi-scout.serviceAccountName" . }}
           {{- with .Values.nodeSelector }}
           nodeSelector: {{ toJson . }}

--- a/charts/nhi-scout/templates/_cronjob.tpl
+++ b/charts/nhi-scout/templates/_cronjob.tpl
@@ -20,11 +20,12 @@ spec:
             {{ toYaml . | nindent 12 }}
             {{- end }}
         spec:
-          securityContext: {{ toJson .Values.securityContext }}
+          {{- include "nhi-scout.securityContext" $ | indent 10 }}
           containers:
             - name: {{ .Chart.Name }}
               image: "{{ .Values.image.repository }}:{{ .Values.inventory.version }}"
               imagePullPolicy: {{ .Values.image.pullPolicy }}
+              {{- include "nhi-scout.containerSecurityContext" $ | indent 14 }}
               args:
                 - {{ .command }}
                 {{- if .Values.inventory.log_level }}

--- a/charts/nhi-scout/templates/_cronjob.tpl
+++ b/charts/nhi-scout/templates/_cronjob.tpl
@@ -9,6 +9,8 @@ spec:
   schedule: {{ toJson .schedule  }}
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: {{ .ttlSecondsAfterFinished | int }}
+      backoffLimit: {{ .backOffLimit | int }}
       template:
         metadata:
           {{- with .Values.podAnnotations }}

--- a/charts/nhi-scout/templates/_helpers.tpl
+++ b/charts/nhi-scout/templates/_helpers.tpl
@@ -60,3 +60,26 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Security context
+*/}}
+{{- define "nhi-scout.securityContext" }}
+{{- if .Values.securityContext.enabled }}
+{{/* uid for chainguard images */}}{{- $uid := 65532 }}
+securityContext:
+  fsGroup: {{ .Values.securityContext.fsGroup | default $uid }}
+  runAsUser: {{ .Values.securityContext.runAsUser | default $uid }}
+  runAsGroup: {{  .Values.securityContext.runAsGroup | default $uid }}
+  runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+{{- end }}
+{{- end }}
+
+{{/*
+Container security context for backend deployments
+*/}}
+{{- define "nhi-scout.containerSecurityContext" }}
+{{- if .Values.securityContext.enabled }}
+securityContext: {{- toYaml .Values.containerSecurityContext | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/charts/nhi-scout/templates/_helpers.tpl
+++ b/charts/nhi-scout/templates/_helpers.tpl
@@ -47,6 +47,7 @@ Selector labels
 */}}
 {{- define "nhi-scout.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "nhi-scout.name" . }}
+app.kubernetes.io/component: {{ include "nhi-scout.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/nhi-scout/templates/clusterrolebinding.yaml
+++ b/charts/nhi-scout/templates/clusterrolebinding.yaml
@@ -8,8 +8,8 @@ metadata:
     {{- include "nhi-scout.labels" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "nhi-scout.fullname" . }}
-    namespace: {{ .Values.namespace }}
+    name: {{ include "nhi-scout.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
   name: {{ include "nhi-scout.fullname" . }}

--- a/charts/nhi-scout/templates/cronjob_inventory.yaml
+++ b/charts/nhi-scout/templates/cronjob_inventory.yaml
@@ -6,5 +6,5 @@
 {{ $command = "fetch-and-send" -}}
 {{- end }}
 
-{{ include "nhi-scout.cronjob" (merge (dict "cronjob_name" "inventory" "command" $command "schedule" .Values.inventory.jobs.fetch.schedule) .) -}}
+{{ include "nhi-scout.cronjob" (merge (dict "cronjob_name" "inventory" "command" $command "schedule" .Values.inventory.jobs.fetch.schedule "backOffLimit" .Values.inventory.jobs.fetch.backOffLimit "ttlSecondsAfterFinished" .Values.inventory.jobs.fetch.ttlSecondsAfterFinished ) .) -}}
 {{- end }}

--- a/charts/nhi-scout/templates/cronjob_ping.yaml
+++ b/charts/nhi-scout/templates/cronjob_ping.yaml
@@ -1,3 +1,3 @@
 {{- if and (ne .Values.inventory.config.gitguardian nil) (ne .Values.inventory.jobs nil) (ne .Values.inventory.jobs.ping nil)}}
-{{ include "nhi-scout.cronjob" (merge (dict "cronjob_name" "ping" "command" "ping" "schedule" .Values.inventory.jobs.ping.schedule) .) -}}
+{{ include "nhi-scout.cronjob" (merge (dict "cronjob_name" "ping" "command" "ping" "schedule" .Values.inventory.jobs.ping.schedule "backOffLimit" .Values.inventory.jobs.ping.backOffLimit "ttlSecondsAfterFinished" .Values.inventory.jobs.ping.ttlSecondsAfterFinished) .) -}}
 {{- end }}

--- a/charts/nhi-scout/templates/cronjob_sync.yaml
+++ b/charts/nhi-scout/templates/cronjob_sync.yaml
@@ -1,3 +1,3 @@
 {{- if and (ne .Values.inventory.config.gitguardian nil) (.Values.inventory.jobs.sync.enabled) }}
-{{ include "nhi-scout.cronjob" (merge (dict "cronjob_name" "sync" "command" "sync-secrets" "schedule" .Values.inventory.jobs.sync.schedule) .) -}}
+{{ include "nhi-scout.cronjob" (merge (dict "cronjob_name" "sync" "command" "sync-secrets" "schedule" .Values.inventory.jobs.sync.schedule "backOffLimit" .Values.inventory.jobs.sync.backOffLimit "ttlSecondsAfterFinished" .Values.inventory.jobs.sync.ttlSecondsAfterFinished) .) -}}
 {{- end }}

--- a/charts/nhi-scout/tests/base_cronjob_test.yaml
+++ b/charts/nhi-scout/tests/base_cronjob_test.yaml
@@ -125,4 +125,5 @@ tests:
       value:
         runAsUser: 65532
         runAsGroup: 65532
+        runAsNonRoot: true
         fsGroup: 65532

--- a/charts/nhi-scout/tests/clusterrolebinding_test.yaml
+++ b/charts/nhi-scout/tests/clusterrolebinding_test.yaml
@@ -5,10 +5,11 @@ values:
 - ../test_values.yaml
 templates:
 - clusterrolebinding.yaml
+release:
+  namespace: nhi-scout
 set:
   clusterRole.create: true
   serviceAccount.create: true
-  namespace: nhi-scout
 tests:
 - it: should have the correct kind for ClusterRoleBinding
   asserts:

--- a/charts/nhi-scout/values-base-schema.schema.json
+++ b/charts/nhi-scout/values-base-schema.schema.json
@@ -6,7 +6,6 @@
       "additionalProperties": false,
       "type": "object",
       "properties": {
-        "version": {"type": "string"},
         "log_level": {
           "$ref": "inventory-log-level.schema.json"
         },

--- a/charts/nhi-scout/values.schema.json
+++ b/charts/nhi-scout/values.schema.json
@@ -21,10 +21,6 @@
         },
         "log_level": {
           "$ref": "#/definitions/inventory-log-level.schema.json"
-        },
-        "version": {
-          "type": "string",
-          "minLength": 0
         }
       },
       "additionalProperties": false

--- a/charts/nhi-scout/values.yaml
+++ b/charts/nhi-scout/values.yaml
@@ -113,5 +113,3 @@ tolerations: []
 affinity: {}
 
 restartPolicy: Never
-
-namespace: default

--- a/charts/nhi-scout/values.yaml
+++ b/charts/nhi-scout/values.yaml
@@ -67,17 +67,29 @@ podAnnotations: {}
 # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 podLabels: {}
 
-# Example:
-# capabilities:
-#   drop:
-#   - ALL
-# readOnlyRootFilesystem: true
-# runAsNonRoot: true
-# runAsUser: 1000
 securityContext:
-  runAsUser: 65532
-  runAsGroup: 65532
-  fsGroup: 65532
+  # -- Enable security Context in deployments.
+  # Set to false when deploying on OpenShift
+  enabled: true
+  # @ignored
+  runAsNonRoot: true
+  # @ignored
+  runAsUser: null
+  # @ignored
+  runAsGroup: null
+  # @ignored
+  fsGroup: null
+
+# -- Specify Container Security Context in deployments.
+# Note: Enabled if `securityContext.enabled` is true.
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  privileged: false
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop:
+    - ALL
 
 # We usually recommend not to specify default resources and to leave this as a conscious
 # choice for the user. This also increases chances charts run on environments with little

--- a/charts/nhi-scout/values.yaml
+++ b/charts/nhi-scout/values.yaml
@@ -4,8 +4,6 @@
 
 # Options for the inventory configuration.
 inventory:
-  # Specific version of the image to use
-  version: 0.12.0
   # Schedule to run the collection on
   log_level: info
   # Enable syncing secrets to vaults
@@ -26,14 +24,18 @@ inventory:
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: ghcr.io/gitguardian/gitguardian-nhi-scout/chainguard
-  # This sets the pull policy for images.
-  pullPolicy: IfNotPresent
+  registry: ghcr.io
+  name: gitguardian/gitguardian-nhi-scout/chainguard
+  # App version
+  tag: 0.12.0
+  # This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  # Example:
+  # - name: my-secret
+  pullSecrets: []
 
-# This is for the secretes for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-# Example:
-# - name: my-secret
-imagePullSecrets: []
+# This sets the pull policy for images.
+imagePullPolicy: IfNotPresent
+
 # This is to override the chart name.
 nameOverride: ""
 fullnameOverride: ""

--- a/charts/nhi-scout/values.yaml
+++ b/charts/nhi-scout/values.yaml
@@ -13,13 +13,19 @@ inventory:
   jobs:
     ping:
       schedule: "* * * * *"
+      backOffLimit: 2
+      ttlSecondsAfterFinished: 2592000 #30 days
     fetch:
       schedule: "*/15 * * * *"
       enabled: false
       send: false
+      backOffLimit: 2
+      ttlSecondsAfterFinished: 2592000 #30 days
     sync:
       schedule: "* * * * *"
       enabled: false
+      backOffLimit: 2
+      ttlSecondsAfterFinished: 2592000 #30 days
 
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/


### PR DESCRIPTION
- [Define securityContexts ](https://linear.app/gitguardian/issue/ENT-2608/nhi-scout-fails-to-run-job-when-enforcing-pod-security-policy): This is required when Pod Security Policies are enforced
- [Global values to inherit from registry and imagePullSecrets from GIM](https://linear.app/gitguardian/issue/ENT-2603/nhi-scout-adapt-helm-chart-values-to-inherit-global-values-from-parent) : `global.imageRegistry` takes precedence and `global.imagePullSecrets` are added to Jobs
- [Fix an issue with SA namespace in CRBinding](https://linear.app/gitguardian/issue/ENT-2641/nhi-scout-fix-clusterrolebinding-namespace-issue)
- [Define ttlSecondsAfterFinished and backoffLimit for jobs](https://linear.app/gitguardian/issue/ENT-2605/nhi-scout-include-logs-in-the-supportbundle) : This is to define retention for support bundles logs. Default values are defined, could be overloaded if needed.