### PR TITLE
feat(ca): improve CA certificates handling

### DIFF
--- a/charts/nhi-scout/examples/custom_certificates/values.yaml
+++ b/charts/nhi-scout/examples/custom_certificates/values.yaml
@@ -1,30 +1,21 @@
 ---
 # yaml-language-server: $schema=../../values.schema.json
 
-# Custom certificates are configured by setting either of the following environment variables:
-# - SSL_CERT_FILE
-# - SSL_CERT_DIR
-# The value of these environment variables should be the path to the custom certificate file or directory.
-# These certificates will be configured to be used when authenticating remote servers.
+# Custom certificates are configured by setting the caBundle parameter.
 
-env:
-  # If you want to use a single certificate:
-- name: "SSL_CERT_FILE"
-  value: "/etc/ssl/certs/my-custom-certificates/my-custom-certificate.crt"
-  # Or, if you have multiple certificates:
-- name: "SSL_CERT_DIR"
-  value: "/etc/ssl/certs/my-custom-certificates/"
-
-# Mount the certificate from a secret into the pod, at the specified path:
-volumes:
-- name: my-custom-certificates
-  secret:
-    secretName: my-custom-certificates
-
-volumeMounts:
-- name: my-custom-certificates
-  mountPath: /etc/ssl/certs/my-custom-certificates/
-  readOnly: true
+caBundle:
+  # Specify CA certificates to inject (PEM format)
+  certs: |
+    -----BEGIN CERTIFICATE-----
+    Cert 1
+    -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    Cert 2
+    -----END CERTIFICATE-----
+  # Or you can specify a secret containing CA certificates to inject
+  existingSecret: my-custom-certificates
+  # Specify secret key under the CA certificate is stored
+  existingSecretKey: ca.crt
 
 inventory:
   config:

--- a/charts/nhi-scout/templates/_cronjob.tpl
+++ b/charts/nhi-scout/templates/_cronjob.tpl
@@ -23,6 +23,29 @@ spec:
             {{- end }}
         spec:
           {{- include "nhi-scout.securityContext" $ | indent 10 }}
+          {{- if or $.Values.caBundle.certs $.Values.caBundle.existingSecret }}
+          initContainers:
+            - name: init-ca
+              {{- include "nhi-scout.containerSecurityContext" . | indent 14 }}
+              image: {{ include "nhi-scout.caBundle.image" . }}
+              imagePullPolicy: {{ .Values.imagePullPolicy }}
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -x
+                  cat $SSL_CERT_FILE >/etc/ssl/custom-certs/ca-bundle.crt
+
+                  # Add private CA certificates bundle
+                  if [[ -s /etc/ssl/ca-bundle/ca-bundle.crt ]]; then
+                    cat /etc/ssl/ca-bundle/ca-bundle.crt >>/etc/ssl/custom-certs/ca-bundle.crt
+                  fi
+              volumeMounts:
+                - name: ssl-custom-certs
+                  mountPath: /etc/ssl/custom-certs
+                - name: ssl-ca-bundle
+                  mountPath: /etc/ssl/ca-bundle
+                  readOnly: true
+          {{- end }}
           containers:
             - name: {{ .Chart.Name }}
               image: {{ include "nhi-scout.image" . }}
@@ -38,12 +61,19 @@ spec:
               env:
                 - name: INVENTORY_CONFIG_PATH
                   value: /etc/inventory/config.yml
+              {{- if or .Values.caBundle.certs .Values.caBundle.existingSecret }}
+                - name: SSL_CERT_FILE
+                  value: /etc/ssl/custom-certs/ca-bundle.crt
+              {{- end }}
               {{- range .Values.env }}
                 - {{ toJson . }}
               {{- end }}
               volumeMounts:
                 - name: config
                   mountPath: /etc/inventory
+                - name: ssl-custom-certs
+                  mountPath: /etc/ssl/custom-certs
+                  readOnly: true
                 {{- range .Values.volumeMounts }}
                 - {{ toJson . }}
                 {{- end }}
@@ -64,6 +94,23 @@ spec:
             - name: config
               secret:
                 secretName: {{ include "nhi-scout.fullname" . }}
+            - name: ssl-custom-certs
+              emptyDir: {}
+            {{- if or .Values.caBundle.certs .Values.caBundle.existingSecret }}
+            - name: ssl-ca-bundle
+              secret:
+                {{- if .Values.caBundle.certs }}
+                secretName: {{ printf "%s-ca-bundle" (include "nhi-scout.fullname" .) }}
+                items:
+                  - key: ca.crt
+                    path: ca-bundle.crt
+                {{- else }}
+                secretName: {{ .Values.caBundle.existingSecret }}
+                items:
+                  - key: {{ default "ca.crt" .Values.caBundle.existingSecretKey }}
+                    path: ca-bundle.crt
+                {{- end }}
+            {{- end }}
             {{- range .Values.volumes }}
             - {{ toJson . }}
             {{- end }}

--- a/charts/nhi-scout/templates/_helpers.tpl
+++ b/charts/nhi-scout/templates/_helpers.tpl
@@ -116,6 +116,36 @@ it will take precedence over registry defined in image.
 {{- end -}}
 
 {{/*
+{{ include "nhi-scout.caBundle.image" }}
+Return the proper nhi-scout caBundle image name.
+Image schema:
+  image:
+    registry: ""
+    name: ""
+    tag: ""
+By default , concatenate values like this "<registry>/<name>:<tag>", but if global.imageRegistry is defined,
+it will take precedence over registry defined in image.
+*/}}
+{{- define "nhi-scout.caBundle.image" -}}
+{{- $registry := .Values.caBundle.image.registry -}}
+{{- $name := .Values.caBundle.image.name -}}
+{{- $tag := (default .Chart.AppVersion .Values.caBundle.image.tag) | toString -}}
+{{- with .Values.global -}}
+  {{- if .imageRegistry -}}
+    {{- $registry = .imageRegistry -}}
+  {{- end -}}
+{{- end -}}
+{{- if $registry -}}
+  {{- $name = printf "%s/%s" $registry $name -}}
+{{- end -}}
+{{- if hasPrefix "sha256:" $tag -}}
+  {{- printf "%s@%s" $name $tag -}}
+{{- else -}}
+  {{- printf "%s:%s" $name $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Return the proper Docker Image Registry Secret Names evaluating values as templates, and following these rules:
 - Include all existing secret names defined in global.imagePullSecrets:
   global:
@@ -167,4 +197,3 @@ imagePullSecrets
 {{- define "nhi-scout.imagePullSecrets" -}}
     {{ include "nhi-scout.common.imagePullSecrets" ( dict "images" (list $.Values.image) "context" $) }}
 {{- end -}}
-

--- a/charts/nhi-scout/templates/secret.yaml
+++ b/charts/nhi-scout/templates/secret.yaml
@@ -8,3 +8,16 @@ metadata:
 type: Opaque
 data:
   config.yml: {{ toYaml .Values.inventory.config | b64enc | quote}}
+
+{{- if .Values.caBundle.certs }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-ca-bundle" (include "nhi-scout.fullname" .) }}
+  labels:
+    {{- include "nhi-scout.labels" . | nindent 4 }}
+type: Opaque
+data:
+  ca.crt: {{ .Values.caBundle.certs | b64enc }}
+{{- end }}

--- a/charts/nhi-scout/tests/custom_certificates_test.yaml
+++ b/charts/nhi-scout/tests/custom_certificates_test.yaml
@@ -1,0 +1,55 @@
+---
+# Test docs: https://github.com/helm-unittest/helm-unittest/blob/main/DOCUMENT.md
+suite: test custom certificates
+values:
+- ../test_values.yaml
+templates:
+- cronjob_ping.yaml
+set:
+  caBundle.image.tag: latest
+  inventory.config.gitguardian.api_token: "foobar"
+  inventory.config.gitguardian.endpoint: "https://some-url.com"
+tests:
+# Providing CA Certificates with .Values.caBundle.certs
+- it: should work
+  set:
+    caBundle.certs: "myCustomCertificate"
+  asserts:
+  - isKind:
+      of: CronJob
+  - equal:
+      path: spec.jobTemplate.spec.template.spec.initContainers[0].image
+      value: ghcr.io/gitguardian/gitguardian-nhi-scout/chainguard-bash:latest
+- it: should work
+  set:
+    caBundle.certs: "myCustomCertificate"
+  asserts:
+  - isKind:
+      of: CronJob
+  - equal:
+      path: spec.jobTemplate.spec.template.spec.containers[0].env[1]
+      value:
+        name: SSL_CERT_FILE
+        value: "/etc/ssl/custom-certs/ca-bundle.crt"
+
+# Providing CA Certificates with Existing Secret
+- it: should work
+  set:
+    caBundle.existingSecret: "myExistingSecret"
+  asserts:
+  - isKind:
+      of: CronJob
+  - equal:
+      path: spec.jobTemplate.spec.template.spec.initContainers[0].image
+      value: ghcr.io/gitguardian/gitguardian-nhi-scout/chainguard-bash:latest
+- it: should work
+  set:
+    caBundle.existingSecret: "myExistingSecret"
+  asserts:
+  - isKind:
+      of: CronJob
+  - equal:
+      path: spec.jobTemplate.spec.template.spec.containers[0].env[1]
+      value:
+        name: SSL_CERT_FILE
+        value: "/etc/ssl/custom-certs/ca-bundle.crt"

--- a/charts/nhi-scout/tests/secret_test.yaml
+++ b/charts/nhi-scout/tests/secret_test.yaml
@@ -7,6 +7,7 @@ templates:
 - secret.yaml
 tests:
 - it: should work
+  documentIndex: 0
   set:
     inventory:
       config:
@@ -26,3 +27,17 @@ tests:
       path: data["config.yml"]
       # Base64 encoded content of .Values.inventory.config
       value: "c291cmNlczoKICBrdWJlOgogICAgY29uZmlnX3NvdXJjZToga3ViZWNvbmZpZ2ZpbGUKICAgIG5hbWU6IG15LWNsdXN0ZXIKICAgIHR5cGU6IGs4cw=="
+- it: should work
+  documentIndex: 1
+  set:
+    caBundle.certs: "myCustomCertificate"
+  asserts:
+  - isKind:
+      of: Secret
+  - matchRegex:
+      path: metadata.name
+      pattern: -nhi-scout-ca-bundle$
+  - equal:
+      path: data["ca.crt"]
+      # Base64 encoded content of .Values.caBundle.certs
+      value: "bXlDdXN0b21DZXJ0aWZpY2F0ZQ=="

--- a/charts/nhi-scout/values.yaml
+++ b/charts/nhi-scout/values.yaml
@@ -28,6 +28,17 @@ inventory:
       backOffLimit: 2
       ttlSecondsAfterFinished: 2592000 #30 days
 
+caBundle:
+  # -- Specify CA certificates to inject (PEM format)
+  certs: ""
+  # -- Specify the secret containing the CA certificate to inject
+  existingSecret: ""
+  # -- Specify secret key under the CA certificated is stored
+  existingSecretKey: ca.crt
+  image:
+    registry: ghcr.io
+    name: gitguardian/gitguardian-nhi-scout/chainguard-bash
+    tag: 0.14.0
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:


### PR DESCRIPTION
Today, we allow users to specify custom CAs via Helm values relying on **SSL_CERT_FILE**/**SSL_CERT_DIR** en vars.
But this comes with certain limitations:

- when you set SSL_CERT_FILE, the certificates included in the image at `/etc/ssl/certs/ca-bundle.crt` are no longer trusted.
- The use of the SSL_CERT_DIR environment variable is not very practical, as it comes with significant setup constraints. Specifically, certificates must be mounted in the container following a strict naming convention: `<hash>.a`, where hash ca n be obtained using openssl command: `openssl x509 -hash -noout -in ca.crt`.

With this PR, we provide a simpler way to specify a list of CAs to inject into NHI pods by introducing the Helm parameter `caBundle`:

```yaml
caBundle:
  # Specify CA certificates to inject (PEM format)
  certs: |
    -----BEGIN CERTIFICATE-----
    Cert 1
    -----END CERTIFICATE-----
    -----BEGIN CERTIFICATE-----
    Cert 2
    -----END CERTIFICATE-----
  # Or you can specify a secret containing CA certificates to inject
  existingSecret: my-custom-certificates
  # Specify secret key under the CA certificate is stored
  existingSecretKey: ca.crt
```

CAs will now be injected using an initContainer that concatenates existing CAs with custom CAs.
