### PR TITLE
feat(helm): add hash cache persistence support

### DIFF
--- a/.github/workflows/validate-helm-examples.yml
+++ b/.github/workflows/validate-helm-examples.yml
@@ -115,7 +115,7 @@ jobs:
       matrix:
         example-group:
           - secret_manager_group_1: ["akeyless", "cyberarksaas", "hashicorpvault", "azurekeyvault"]
-          - secret_manager_group_2: ["delinea", "gcpsecretmanager", "awssecretsmanager"]  # TODO: add fetch-only
+          - secret_manager_group_2: ["gcpsecretmanager", "awssecretsmanager"]  # TODO: add fetch-only, delinea (credentials expired)
           # - consumers: ["k8s_incluster", "k8s_kubeconfigfile", "gitlabci"]
 
     steps:
@@ -170,6 +170,35 @@ jobs:
           echo "${{ secrets.GCP_SA_KEY }}" | base64 --decode > gcp_key.json
           kubectl create secret generic gcp-key-secret --namespace ggscout-test --from-file=gcp_key.json
           echo "✅ Secret gcp-key-secret created with GCP credentials"
+
+      # Verify GitGuardian API credentials before deploying
+      - name: Verify GitGuardian API credentials
+        env:
+          GITGUARDIAN_API_URL: ${{ secrets.GITGUARDIAN_API_URL }}
+          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+        run: |
+          echo "🔍 Testing GitGuardian API connectivity..."
+          echo "Endpoint: ${GITGUARDIAN_API_URL}"
+
+          # Test the ping endpoint (POST) which requires the same auth
+          HTTP_STATUS=$(curl -s -o /tmp/gg_response.json -w "%{http_code}" \
+            -X POST \
+            -H "Authorization: Token ${GITGUARDIAN_API_KEY}" \
+            -H "Content-Type: application/json" \
+            -d '[]' \
+            "${GITGUARDIAN_API_URL%/}/nhi/ping")
+
+          echo "HTTP Status: $HTTP_STATUS"
+          echo "Response body:"
+          cat /tmp/gg_response.json
+          echo ""
+
+          if [ "$HTTP_STATUS" -ge 400 ]; then
+            echo "❌ GitGuardian API authentication failed (HTTP $HTTP_STATUS)"
+            echo "Check that GITGUARDIAN_API_KEY and GITGUARDIAN_API_URL secrets are correct"
+            exit 1
+          fi
+          echo "✅ GitGuardian API credentials verified"
 
       # Deploy and validate each example in the cluster
       - name: Deploy and validate examples

--- a/README.md
+++ b/README.md
@@ -86,6 +86,41 @@ To apply the secrets to your cluster/namespace, run the following command: `kube
 
 Other examples can be found in [charts/ggscout/examples](charts/ggscout/examples).
 
+## Hash Cache Persistence
+
+ggscout uses scrypt to hash secrets before sending them to GitGuardian. By default, hashes are recomputed from scratch on every CronJob run. For large vaults this can be slow.
+
+Enabling persistence creates a PVC that stores the hash cache across runs, so only new or changed secrets need to be hashed:
+
+```yaml
+persistence:
+  enabled: true
+```
+
+On the first run the cache is empty (all misses). On subsequent runs, unchanged secrets are served from cache (hits), skipping expensive scrypt computation.
+
+### Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `persistence.enabled` | Enable persistent hash cache | `false` |
+| `persistence.storageClassName` | StorageClass name (empty = cluster default) | `""` |
+| `persistence.size` | PVC size (64 bytes/entry, 100Mi handles ~1.6M secrets) | `100Mi` |
+| `persistence.existingClaim` | Use an existing PVC instead of creating one | `""` |
+
+### Using an existing PVC
+
+If you already have a PVC you want to reuse:
+
+```yaml
+persistence:
+  enabled: true
+  existingClaim: my-existing-pvc
+```
+
+> [!NOTE]
+> The cache is only mounted on the inventory CronJob (fetch/fetch-and-send). The ping and sync CronJobs do not perform hashing and are unaffected.
+
 > [!IMPORTANT]
 > If you want to only fetch the identities without sending them, please see this [example](charts/ggscout/examples/fetch-only)
 

--- a/charts/ggscout/templates/_cronjob.tpl
+++ b/charts/ggscout/templates/_cronjob.tpl
@@ -25,8 +25,11 @@ spec:
             {{- end }}
         spec:
           {{- include "ggscout.securityContext" $ | indent 10 }}
-          {{- if or $.Values.caBundle.certs $.Values.caBundle.existingSecret }}
+          {{- $needsCaInit := or $.Values.caBundle.certs $.Values.caBundle.existingSecret }}
+          {{- $needsCacheTTL := and .use_cache_pvc .Values.persistence.enabled (gt (int .Values.persistence.cacheTTLSeconds) 0) }}
+          {{- if or $needsCaInit $needsCacheTTL }}
           initContainers:
+            {{- if $needsCaInit }}
             - name: init-ca
               {{- include "ggscout.containerSecurityContext" . | indent 14 }}
               image: {{ include "ggscout.caBundle.image" . }}
@@ -47,6 +50,32 @@ spec:
                 - name: ssl-ca-bundle
                   mountPath: /etc/ssl/ca-bundle
                   readOnly: true
+            {{- end }}
+            {{- if $needsCacheTTL }}
+            - name: cache-ttl-check
+              {{- include "ggscout.containerSecurityContext" . | indent 14 }}
+              image: {{ include "ggscout.caBundle.image" . }}
+              imagePullPolicy: {{ .Values.imagePullPolicy }}
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  CACHE="/var/cache/ggscout/hashcache"
+                  TTL={{ .Values.persistence.cacheTTLSeconds }}
+                  if [ -f "$CACHE" ]; then
+                    AGE=$(( $(date +%s) - $(stat -c %Y "$CACHE") ))
+                    if [ "$AGE" -gt "$TTL" ]; then
+                      echo "Cache is ${AGE}s old (TTL=${TTL}s), flushing stale cache"
+                      rm -f "$CACHE"
+                    else
+                      echo "Cache is ${AGE}s old (TTL=${TTL}s), keeping"
+                    fi
+                  else
+                    echo "No cache file found, cold run"
+                  fi
+              volumeMounts:
+                - name: hashcache
+                  mountPath: /var/cache/ggscout
+            {{- end }}
           {{- end }}
           containers:
             - name: {{ .Chart.Name }}

--- a/charts/ggscout/templates/_cronjob.tpl
+++ b/charts/ggscout/templates/_cronjob.tpl
@@ -67,6 +67,10 @@ spec:
                 - name: SSL_CERT_FILE
                   value: /etc/ssl/custom-certs/ca-bundle.crt
               {{- end }}
+              {{- if and .use_cache_pvc .Values.persistence.enabled }}
+                - name: HASH_CACHE_PATH
+                  value: /var/cache/ggscout/hashcache
+              {{- end }}
               {{- range .Values.env }}
                 - {{ toJson . }}
               {{- end }}
@@ -76,6 +80,10 @@ spec:
                 - name: ssl-custom-certs
                   mountPath: /etc/ssl/custom-certs
                   readOnly: true
+                {{- if and .use_cache_pvc .Values.persistence.enabled }}
+                - name: hashcache
+                  mountPath: /var/cache/ggscout
+                {{- end }}
                 {{- range .Values.volumeMounts }}
                 - {{ toJson . }}
                 {{- end }}
@@ -112,6 +120,11 @@ spec:
                   - key: {{ default "ca.crt" .Values.caBundle.existingSecretKey }}
                     path: ca-bundle.crt
                 {{- end }}
+            {{- end }}
+            {{- if and .use_cache_pvc .Values.persistence.enabled }}
+            - name: hashcache
+              persistentVolumeClaim:
+                claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{ else }}{{ include "ggscout.fullname" . }}-hashcache{{ end }}
             {{- end }}
             {{- range .Values.volumes }}
             - {{ toJson . }}

--- a/charts/ggscout/templates/cronjob_inventory.yaml
+++ b/charts/ggscout/templates/cronjob_inventory.yaml
@@ -6,5 +6,5 @@
 {{ $command = "fetch-and-send" -}}
 {{- end }}
 
-{{ include "ggscout.cronjob" (merge (dict "cronjob_name" "inventory" "command" $command "schedule" .Values.inventory.jobs.fetch.schedule "backOffLimit" .Values.inventory.jobs.fetch.backOffLimit "ttlSecondsAfterFinished" .Values.inventory.jobs.fetch.ttlSecondsAfterFinished ) .) -}}
+{{ include "ggscout.cronjob" (merge (dict "cronjob_name" "inventory" "command" $command "schedule" .Values.inventory.jobs.fetch.schedule "backOffLimit" .Values.inventory.jobs.fetch.backOffLimit "ttlSecondsAfterFinished" .Values.inventory.jobs.fetch.ttlSecondsAfterFinished "use_cache_pvc" true ) .) -}}
 {{- end }}

--- a/charts/ggscout/templates/persistentvolumeclaim.yaml
+++ b/charts/ggscout/templates/persistentvolumeclaim.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ggscout.fullname" . }}-hashcache
+  labels:
+    {{- include "ggscout.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClassName }}
+  storageClassName: {{ .Values.persistence.storageClassName }}
+  {{- end }}
+{{- end }}

--- a/charts/ggscout/templates/persistentvolumeclaim.yaml
+++ b/charts/ggscout/templates/persistentvolumeclaim.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) .Values.inventory.jobs.fetch.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/ggscout/tests/persistence_test.yaml
+++ b/charts/ggscout/tests/persistence_test.yaml
@@ -6,6 +6,7 @@ suite: test persistence
 templates:
 - persistentvolumeclaim.yaml
 set:
+  inventory.jobs.fetch.enabled: true
   inventory.config.gitguardian.api_token: "foobar"
   inventory.config.gitguardian.endpoint: "https://some-url.com"
 tests:
@@ -43,6 +44,14 @@ tests:
   set:
     persistence.enabled: true
     persistence.existingClaim: my-existing-pvc
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should not create PVC when inventory fetch is disabled
+  set:
+    persistence.enabled: true
+    inventory.jobs.fetch.enabled: false
   asserts:
   - hasDocuments:
       count: 0
@@ -119,3 +128,45 @@ tests:
       content:
         name: hashcache
       any: true
+
+- it: should render cache-ttl-check initContainer when persistence is enabled with default TTL
+  set:
+    persistence.enabled: true
+  asserts:
+  - contains:
+      path: spec.jobTemplate.spec.template.spec.initContainers
+      content:
+        name: cache-ttl-check
+      any: true
+
+- it: should mount hashcache volume in cache-ttl-check initContainer
+  set:
+    persistence.enabled: true
+  asserts:
+  - contains:
+      path: spec.jobTemplate.spec.template.spec.initContainers[0].volumeMounts
+      content:
+        name: hashcache
+        mountPath: /var/cache/ggscout
+
+- it: should include TTL value in cache-ttl-check args
+  set:
+    persistence.enabled: true
+    persistence.cacheTTLSeconds: 3600
+  asserts:
+  - matchRegex:
+      path: spec.jobTemplate.spec.template.spec.initContainers[0].args[0]
+      pattern: "TTL=3600"
+
+- it: should not render cache-ttl-check initContainer when cacheTTLSeconds is 0
+  set:
+    persistence.enabled: true
+    persistence.cacheTTLSeconds: 0
+  asserts:
+  - isNull:
+      path: spec.jobTemplate.spec.template.spec.initContainers
+
+- it: should not render cache-ttl-check initContainer when persistence is disabled
+  asserts:
+  - isNull:
+      path: spec.jobTemplate.spec.template.spec.initContainers

--- a/charts/ggscout/tests/persistence_test.yaml
+++ b/charts/ggscout/tests/persistence_test.yaml
@@ -1,0 +1,121 @@
+---
+# Test docs: https://github.com/helm-unittest/helm-unittest/blob/main/DOCUMENT.md
+
+# --- PVC tests ---
+suite: test persistence
+templates:
+- persistentvolumeclaim.yaml
+set:
+  inventory.config.gitguardian.api_token: "foobar"
+  inventory.config.gitguardian.endpoint: "https://some-url.com"
+tests:
+- it: should not create PVC when persistence is disabled (default)
+  asserts:
+  - hasDocuments:
+      count: 0
+
+- it: should create PVC when persistence is enabled
+  set:
+    persistence.enabled: true
+  asserts:
+  - isKind:
+      of: PersistentVolumeClaim
+  - matchRegex:
+      path: metadata.name
+      pattern: .*-hashcache$
+  - equal:
+      path: spec.accessModes[0]
+      value: ReadWriteOnce
+  - equal:
+      path: spec.resources.requests.storage
+      value: 100Mi
+
+- it: should apply custom storageClassName
+  set:
+    persistence.enabled: true
+    persistence.storageClassName: fast-ssd
+  asserts:
+  - equal:
+      path: spec.storageClassName
+      value: fast-ssd
+
+- it: should not create PVC when existingClaim is set
+  set:
+    persistence.enabled: true
+    persistence.existingClaim: my-existing-pvc
+  asserts:
+  - hasDocuments:
+      count: 0
+---
+# --- Inventory CronJob persistence tests ---
+suite: test persistence in inventory cronjob
+templates:
+- cronjob_inventory.yaml
+set:
+  inventory.jobs.fetch.enabled: true
+  inventory.config.gitguardian.api_token: "foobar"
+  inventory.config.gitguardian.endpoint: "https://some-url.com"
+tests:
+- it: should inject HASH_CACHE_PATH env var when persistence is enabled
+  set:
+    persistence.enabled: true
+  asserts:
+  - contains:
+      path: spec.jobTemplate.spec.template.spec.containers[0].env
+      content:
+        name: HASH_CACHE_PATH
+        value: /var/cache/ggscout/hashcache
+
+- it: should not inject HASH_CACHE_PATH env var when persistence is disabled
+  asserts:
+  - notContains:
+      path: spec.jobTemplate.spec.template.spec.containers[0].env
+      content:
+        name: HASH_CACHE_PATH
+        value: /var/cache/ggscout/hashcache
+
+- it: should add hashcache volumeMount when persistence is enabled
+  set:
+    persistence.enabled: true
+  asserts:
+  - contains:
+      path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+      content:
+        name: hashcache
+        mountPath: /var/cache/ggscout
+
+- it: should add hashcache volume with generated claimName when persistence is enabled
+  set:
+    persistence.enabled: true
+  asserts:
+  - contains:
+      path: spec.jobTemplate.spec.template.spec.volumes
+      content:
+        name: hashcache
+        persistentVolumeClaim:
+          claimName: RELEASE-NAME-ggscout-hashcache
+
+- it: should use existingClaim as claimName when specified
+  set:
+    persistence.enabled: true
+    persistence.existingClaim: my-existing-pvc
+  asserts:
+  - contains:
+      path: spec.jobTemplate.spec.template.spec.volumes
+      content:
+        name: hashcache
+        persistentVolumeClaim:
+          claimName: my-existing-pvc
+
+- it: should not add hashcache volume or mount when persistence is disabled
+  asserts:
+  - notContains:
+      path: spec.jobTemplate.spec.template.spec.containers[0].volumeMounts
+      content:
+        name: hashcache
+        mountPath: /var/cache/ggscout
+  - notContains:
+      path: spec.jobTemplate.spec.template.spec.volumes
+      content:
+        name: hashcache
+      any: true

--- a/charts/ggscout/values-base-schema.schema.json
+++ b/charts/ggscout/values-base-schema.schema.json
@@ -17,6 +17,33 @@
        }
       },
       "required": ["config"]
+    },
+    "persistence": {
+      "type": "object",
+      "description": "Hash cache persistence. Creates a PVC for the scrypt hash cache so it survives across CronJob runs.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable persistent hash cache",
+          "default": false
+        },
+        "storageClassName": {
+          "type": "string",
+          "description": "StorageClass name. Empty uses the cluster default.",
+          "default": ""
+        },
+        "size": {
+          "type": "string",
+          "description": "PVC size (64 bytes/entry, 100Mi handles ~1.6M secrets)",
+          "default": "100Mi"
+        },
+        "existingClaim": {
+          "type": "string",
+          "description": "Use an existing PVC instead of creating one",
+          "default": ""
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": [

--- a/charts/ggscout/values-base-schema.schema.json
+++ b/charts/ggscout/values-base-schema.schema.json
@@ -41,6 +41,12 @@
           "type": "string",
           "description": "Use an existing PVC instead of creating one",
           "default": ""
+        },
+        "cacheTTLSeconds": {
+          "type": "integer",
+          "description": "Cache staleness TTL in seconds. If no inventory job has run for this duration, the cache is flushed on the next run. Set to 0 to disable.",
+          "default": 86400,
+          "minimum": 0
         }
       },
       "additionalProperties": false

--- a/charts/ggscout/values.schema.json
+++ b/charts/ggscout/values.schema.json
@@ -24,28 +24,28 @@
       "additionalProperties": false
     },
     "persistence": {
-      "type": "object",
       "description": "Hash cache persistence. Creates a PVC for the scrypt hash cache so it survives across CronJob runs.",
+      "type": "object",
       "properties": {
         "enabled": {
-          "type": "boolean",
           "description": "Enable persistent hash cache",
-          "default": false
-        },
-        "storageClassName": {
-          "type": "string",
-          "description": "StorageClass name. Empty uses the cluster default.",
-          "default": ""
-        },
-        "size": {
-          "type": "string",
-          "description": "PVC size (64 bytes/entry, 100Mi handles ~1.6M secrets)",
-          "default": "100Mi"
+          "default": false,
+          "type": "boolean"
         },
         "existingClaim": {
-          "type": "string",
           "description": "Use an existing PVC instead of creating one",
-          "default": ""
+          "default": "",
+          "type": "string"
+        },
+        "size": {
+          "description": "PVC size (64 bytes/entry, 100Mi handles ~1.6M secrets)",
+          "default": "100Mi",
+          "type": "string"
+        },
+        "storageClassName": {
+          "description": "StorageClass name. Empty uses the cluster default.",
+          "default": "",
+          "type": "string"
         }
       },
       "additionalProperties": false

--- a/charts/ggscout/values.schema.json
+++ b/charts/ggscout/values.schema.json
@@ -27,6 +27,12 @@
       "description": "Hash cache persistence. Creates a PVC for the scrypt hash cache so it survives across CronJob runs.",
       "type": "object",
       "properties": {
+        "cacheTTLSeconds": {
+          "description": "Cache staleness TTL in seconds. If no inventory job has run for this duration, the cache is flushed on the next run. Set to 0 to disable.",
+          "default": 86400,
+          "type": "integer",
+          "minimum": 0
+        },
         "enabled": {
           "description": "Enable persistent hash cache",
           "default": false,

--- a/charts/ggscout/values.schema.json
+++ b/charts/ggscout/values.schema.json
@@ -22,6 +22,33 @@
         }
       },
       "additionalProperties": false
+    },
+    "persistence": {
+      "type": "object",
+      "description": "Hash cache persistence. Creates a PVC for the scrypt hash cache so it survives across CronJob runs.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enable persistent hash cache",
+          "default": false
+        },
+        "storageClassName": {
+          "type": "string",
+          "description": "StorageClass name. Empty uses the cluster default.",
+          "default": ""
+        },
+        "size": {
+          "type": "string",
+          "description": "PVC size (64 bytes/entry, 100Mi handles ~1.6M secrets)",
+          "default": "100Mi"
+        },
+        "existingClaim": {
+          "type": "string",
+          "description": "Use an existing PVC instead of creating one",
+          "default": ""
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": true,

--- a/charts/ggscout/values.yaml
+++ b/charts/ggscout/values.yaml
@@ -28,6 +28,18 @@ inventory:
       backOffLimit: 2
       ttlSecondsAfterFinished: 2592000 #30 days
 
+# Hash cache persistence. When enabled, a PVC is created and mounted into
+# the inventory CronJob so the scrypt hash cache survives across runs.
+persistence:
+  # -- Enable persistent hash cache
+  enabled: false
+  # -- StorageClass name. Empty uses the cluster default.
+  storageClassName: ""
+  # -- PVC size (64 bytes/entry, 100Mi handles ~1.6M secrets)
+  size: 100Mi
+  # -- Use an existing PVC instead of creating one
+  existingClaim: ""
+
 caBundle:
   # -- Specify CA certificates to inject (PEM format)
   certs: ""

--- a/charts/ggscout/values.yaml
+++ b/charts/ggscout/values.yaml
@@ -39,6 +39,10 @@ persistence:
   size: 100Mi
   # -- Use an existing PVC instead of creating one
   existingClaim: ""
+  # -- Cache staleness TTL in seconds. If no inventory job has run for this
+  # duration, the cache is flushed on the next run. Default 86400 = 24 hours.
+  # Set to 0 to disable (cache never expires).
+  cacheTTLSeconds: 86400
 
 caBundle:
   # -- Specify CA certificates to inject (PEM format)

--- a/docs/index.html
+++ b/docs/index.html
@@ -373,6 +373,11 @@
                id="sources_additionalProperties_oneOf_i11" data-toggle="tab" href="#tab-pane_sources_additionalProperties_oneOf_i11" role="tab"
                onclick="setAnchor('#sources_additionalProperties_oneOf_i11')"
             >Delinea Secret Server</a>
+        </li><li class="nav-item">
+            <a class="nav-link oneOf-option"
+               id="sources_additionalProperties_oneOf_i12" data-toggle="tab" href="#tab-pane_sources_additionalProperties_oneOf_i12" role="tab"
+               onclick="setAnchor('#sources_additionalProperties_oneOf_i12')"
+            >GitHub Actions</a>
         </li></ul>
 <div class="tab-content card"><div class="tab-pane fade card-body active show"
              id="tab-pane_sources_additionalProperties_oneOf_i0" role="tabpanel">
@@ -17095,6 +17100,793 @@ This can be found by clicking on "Token API documentation" in the Settings &gt; 
         </svg>
     <a href="#sources_additionalProperties_oneOf_i11_type" onclick="anchorLink('sources_additionalProperties_oneOf_i11_type')">type</a></div><span class="badge badge-dark value-type">Type: const</span><br/>
 <span class="const-value" id="sources_additionalProperties_oneOf_i11_type_const">Specific value: <code>"delineasecretserver"</code></span>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+        </div><div class="tab-pane fade card-body "
+             id="tab-pane_sources_additionalProperties_oneOf_i12" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">GitHub Actions</a></div><h4>GitHub Actions</h4><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>GitHub Actions fetcher</p>
+</span>
+
+    
+        
+
+        
+        
+
+        
+<div class="accordion" id="accordionsources_additionalProperties_oneOf_i12_env">
+    <div class="card">
+        <div class="card-header" id="headingsources_additionalProperties_oneOf_i12_env">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#sources_additionalProperties_oneOf_i12_env"
+                        aria-expanded="" aria-controls="sources_additionalProperties_oneOf_i12_env" onclick="setAnchor('#sources_additionalProperties_oneOf_i12_env')"><span class="property-name">env</span></button>
+            </h2>
+        </div>
+
+        <div id="sources_additionalProperties_oneOf_i12_env"
+             class="collapse property-definition-div" aria-labelledby="headingsources_additionalProperties_oneOf_i12_env"
+             data-parent="#accordionsources_additionalProperties_oneOf_i12_env">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_env" onclick="anchorLink('sources_additionalProperties_oneOf_i12_env')">env</a></div><h4>Environment of this source (prod, pre-prod, staging, test, dev)</h4><br/>
+<div class="any-of-value" id="sources_additionalProperties_oneOf_i12_env_anyOf"><h2 class="handle">
+  <label>Any of</label>
+</h2><ul class="nav nav-tabs" id="tabssources_additionalProperties_oneOf_i12_env_anyOf_anyOf" role="tablist"><li class="nav-item">
+            <a class="nav-link active anyOf-option"
+               id="sources_additionalProperties_oneOf_i12_env_anyOf_i0" data-toggle="tab" href="#tab-pane_sources_additionalProperties_oneOf_i12_env_anyOf_i0" role="tab"
+               onclick="setAnchor('#sources_additionalProperties_oneOf_i12_env_anyOf_i0')"
+            >Env</a>
+        </li><li class="nav-item">
+            <a class="nav-link anyOf-option"
+               id="sources_additionalProperties_oneOf_i12_env_anyOf_i1" data-toggle="tab" href="#tab-pane_sources_additionalProperties_oneOf_i12_env_anyOf_i1" role="tab"
+               onclick="setAnchor('#sources_additionalProperties_oneOf_i12_env_anyOf_i1')"
+            >Option 2</a>
+        </li></ul>
+<div class="tab-content card"><div class="tab-pane fade card-body active show"
+             id="tab-pane_sources_additionalProperties_oneOf_i12_env_anyOf_i0" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_env" onclick="anchorLink('sources_additionalProperties_oneOf_i12_env')">env</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_env_anyOf" onclick="anchorLink('sources_additionalProperties_oneOf_i12_env_anyOf')">anyOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_env_anyOf_i0" onclick="anchorLink('sources_additionalProperties_oneOf_i12_env_anyOf_i0')">Env</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+<span class="description"><p>Declare an environment</p>
+</span><a href="#sources_additionalProperties_oneOf_i0_env_anyOf_i0" onclick="anchorLink('sources_additionalProperties_oneOf_i0_env_anyOf_i0')" class="ref-link">Same definition as sources_additionalProperties_oneOf_i0_env_anyOf_i0</a>
+        </div><div class="tab-pane fade card-body "
+             id="tab-pane_sources_additionalProperties_oneOf_i12_env_anyOf_i1" role="tabpanel">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_env" onclick="anchorLink('sources_additionalProperties_oneOf_i12_env')">env</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_env_anyOf" onclick="anchorLink('sources_additionalProperties_oneOf_i12_env_anyOf')">anyOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_env_anyOf_i1" onclick="anchorLink('sources_additionalProperties_oneOf_i12_env_anyOf_i1')">item 1</a></div><span class="badge badge-dark value-type">Type: const</span><br/>
+<span class="const-value" id="sources_additionalProperties_oneOf_i12_env_anyOf_i1_const">Specific value: <code>null</code></span>
+        
+
+        
+        
+
+        
+        </div></div></div>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsources_additionalProperties_oneOf_i12_exclude">
+    <div class="card">
+        <div class="card-header" id="headingsources_additionalProperties_oneOf_i12_exclude">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#sources_additionalProperties_oneOf_i12_exclude"
+                        aria-expanded="" aria-controls="sources_additionalProperties_oneOf_i12_exclude" onclick="setAnchor('#sources_additionalProperties_oneOf_i12_exclude')"><span class="property-name">exclude</span></button>
+            </h2>
+        </div>
+
+        <div id="sources_additionalProperties_oneOf_i12_exclude"
+             class="collapse property-definition-div" aria-labelledby="headingsources_additionalProperties_oneOf_i12_exclude"
+             data-parent="#accordionsources_additionalProperties_oneOf_i12_exclude">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_exclude" onclick="anchorLink('sources_additionalProperties_oneOf_i12_exclude')">exclude</a></div><span class="badge badge-dark value-type">Type: array</span><br/>
+
+        
+
+        
+        
+
+         <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="sources_additionalProperties_oneOf_i12_exclude_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_exclude" onclick="anchorLink('sources_additionalProperties_oneOf_i12_exclude')">exclude</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_exclude_items" onclick="anchorLink('sources_additionalProperties_oneOf_i12_exclude_items')">FilteringRule</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+<a href="#sources_additionalProperties_oneOf_i0_exclude_items" onclick="anchorLink('sources_additionalProperties_oneOf_i0_exclude_items')" class="ref-link">Same definition as sources_additionalProperties_oneOf_i0_exclude_items</a>
+        </div>
+    </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsources_additionalProperties_oneOf_i12_fetch_all_versions">
+    <div class="card">
+        <div class="card-header" id="headingsources_additionalProperties_oneOf_i12_fetch_all_versions">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#sources_additionalProperties_oneOf_i12_fetch_all_versions"
+                        aria-expanded="" aria-controls="sources_additionalProperties_oneOf_i12_fetch_all_versions" onclick="setAnchor('#sources_additionalProperties_oneOf_i12_fetch_all_versions')"><span class="property-name">fetch_all_versions</span></button>
+            </h2>
+        </div>
+
+        <div id="sources_additionalProperties_oneOf_i12_fetch_all_versions"
+             class="collapse property-definition-div" aria-labelledby="headingsources_additionalProperties_oneOf_i12_fetch_all_versions"
+             data-parent="#accordionsources_additionalProperties_oneOf_i12_fetch_all_versions">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_fetch_all_versions" onclick="anchorLink('sources_additionalProperties_oneOf_i12_fetch_all_versions')">fetch_all_versions</a></div><h4>Whether or not to collect all secret versions (default: false)</h4><span class="badge badge-dark value-type">Type: boolean</span> <span class="badge badge-success default-value">Default: true</span><br/>
+
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsources_additionalProperties_oneOf_i12_include">
+    <div class="card">
+        <div class="card-header" id="headingsources_additionalProperties_oneOf_i12_include">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#sources_additionalProperties_oneOf_i12_include"
+                        aria-expanded="" aria-controls="sources_additionalProperties_oneOf_i12_include" onclick="setAnchor('#sources_additionalProperties_oneOf_i12_include')"><span class="property-name">include</span></button>
+            </h2>
+        </div>
+
+        <div id="sources_additionalProperties_oneOf_i12_include"
+             class="collapse property-definition-div" aria-labelledby="headingsources_additionalProperties_oneOf_i12_include"
+             data-parent="#accordionsources_additionalProperties_oneOf_i12_include">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_include" onclick="anchorLink('sources_additionalProperties_oneOf_i12_include')">include</a></div><span class="badge badge-dark value-type">Type: array</span><br/>
+
+        
+
+        
+        
+
+         <span class="badge badge-info no-additional">No Additional Items</span><h4>Each item of this array must be:</h4>
+    <div class="card">
+        <div class="card-body items-definition" id="sources_additionalProperties_oneOf_i12_include_items">
+            
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_include" onclick="anchorLink('sources_additionalProperties_oneOf_i12_include')">include</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_include_items" onclick="anchorLink('sources_additionalProperties_oneOf_i12_include_items')">FilteringRule</a></div><span class="badge badge-dark value-type">Type: object</span><br/>
+<a href="#sources_additionalProperties_oneOf_i0_exclude_items" onclick="anchorLink('sources_additionalProperties_oneOf_i0_exclude_items')" class="ref-link">Same definition as sources_additionalProperties_oneOf_i0_exclude_items</a>
+        </div>
+    </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsources_additionalProperties_oneOf_i12_mode">
+    <div class="card">
+        <div class="card-header" id="headingsources_additionalProperties_oneOf_i12_mode">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#sources_additionalProperties_oneOf_i12_mode"
+                        aria-expanded="" aria-controls="sources_additionalProperties_oneOf_i12_mode" onclick="setAnchor('#sources_additionalProperties_oneOf_i12_mode')"><span class="property-name">mode</span></button>
+            </h2>
+        </div>
+
+        <div id="sources_additionalProperties_oneOf_i12_mode"
+             class="collapse property-definition-div" aria-labelledby="headingsources_additionalProperties_oneOf_i12_mode"
+             data-parent="#accordionsources_additionalProperties_oneOf_i12_mode">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_mode" onclick="anchorLink('sources_additionalProperties_oneOf_i12_mode')">mode</a></div><h4>Mode of this source (read, write, read/write)</h4><span class="badge badge-dark value-type">Type: enum (of string)</span> <span class="badge badge-success default-value">Default: "read"</span><br/>
+<span class="description"><p>The mode gives an additional layer of permissions allowing to configure a Scout instance, giving read-only, write-only, or read and write permissions to that source. Default is read-only.</p>
+</span>
+
+    <div class="enum-value" id="sources_additionalProperties_oneOf_i0_mode_enum">
+            <h4>Must be one of:</h4>
+            <ul class="list-group"><li class="list-group-item enum-item">"read"</li><li class="list-group-item enum-item">"write"</li><li class="list-group-item enum-item">"read/write"</li></ul>
+            </div>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsources_additionalProperties_oneOf_i12_owner">
+    <div class="card">
+        <div class="card-header" id="headingsources_additionalProperties_oneOf_i12_owner">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#sources_additionalProperties_oneOf_i12_owner"
+                        aria-expanded="" aria-controls="sources_additionalProperties_oneOf_i12_owner" onclick="setAnchor('#sources_additionalProperties_oneOf_i12_owner')"><span class="property-name">owner</span></button>
+            </h2>
+        </div>
+
+        <div id="sources_additionalProperties_oneOf_i12_owner"
+             class="collapse property-definition-div" aria-labelledby="headingsources_additionalProperties_oneOf_i12_owner"
+             data-parent="#accordionsources_additionalProperties_oneOf_i12_owner">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_owner" onclick="anchorLink('sources_additionalProperties_oneOf_i12_owner')">owner</a></div><h4>Owner of this source (an email, usually of an employee or a team)</h4><span class="badge badge-dark value-type">Type: string</span><br/>
+
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsources_additionalProperties_oneOf_i12_token">
+    <div class="card">
+        <div class="card-header" id="headingsources_additionalProperties_oneOf_i12_token">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#sources_additionalProperties_oneOf_i12_token"
+                        aria-expanded="" aria-controls="sources_additionalProperties_oneOf_i12_token" onclick="setAnchor('#sources_additionalProperties_oneOf_i12_token')"><span class="property-name">token</span></button>
+            </h2>
+        </div>
+
+        <div id="sources_additionalProperties_oneOf_i12_token"
+             class="collapse property-definition-div" aria-labelledby="headingsources_additionalProperties_oneOf_i12_token"
+             data-parent="#accordionsources_additionalProperties_oneOf_i12_token">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">item 12</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_token" onclick="anchorLink('sources_additionalProperties_oneOf_i12_token')">token</a></div><span class="badge badge-dark value-type">Type: string</span><br/>
+<div class="description collapse" id="collapseDescription_sources_additionalProperties_oneOf_i12_token">
+            <p>Optional GitHub API token for metadata enrichment via the GitHub REST API.<br />
+When provided, enriches inventory items with <code>created_at</code>, <code>updated_at</code>,<br />
+scope, visibility, and the repository owner's email.<br />
+Graceful degradation: if absent, the fetcher operates on in-workflow data only.</p>
+
+<p>Required token scopes by API endpoint:<br />
+- <strong>Repo secrets</strong> (<code>/repos/{owner}/{repo}/actions/secrets</code>): <code>repo</code> scope<br />
+- <strong>Org secrets</strong> (<code>/orgs/{org}/actions/secrets</code>): <code>admin:org</code> scope<br />
+- <strong>Environment secrets</strong>: <code>repo</code> scope<br />
+- <strong>Owner email</strong> (<code>/users/{owner}</code>): no scope required (public data)</p>
+
+<p>Missing scopes result in 403 warnings in logs; the fetcher continues without<br />
+the corresponding metadata.</p>
+
+        </div>
+        <div>
+            <a class="collapse-description-link collapsed" data-toggle="collapse" href="#collapseDescription_sources_additionalProperties_oneOf_i12_token"
+               aria-expanded="false" aria-controls="collapseDescriptionsources_additionalProperties_oneOf_i12_token"
+            ></a>
+        </div>
+        
+
+        
+        
+
+        
+            </div>
+        </div>
+    </div>
+</div>
+<div class="accordion" id="accordionsources_additionalProperties_oneOf_i12_type">
+    <div class="card">
+        <div class="card-header" id="headingsources_additionalProperties_oneOf_i12_type">
+            <h2 class="mb-0">
+                <button class="btn btn-link property-name-button" type="button" data-toggle="collapse" data-target="#sources_additionalProperties_oneOf_i12_type"
+                        aria-expanded="" aria-controls="sources_additionalProperties_oneOf_i12_type" onclick="setAnchor('#sources_additionalProperties_oneOf_i12_type')"><span class="property-name">type</span> <span class="badge badge-warning required-property">Required</span></button>
+            </h2>
+        </div>
+
+        <div id="sources_additionalProperties_oneOf_i12_type"
+             class="collapse property-definition-div" aria-labelledby="headingsources_additionalProperties_oneOf_i12_type"
+             data-parent="#accordionsources_additionalProperties_oneOf_i12_type">
+            <div class="card-body pl-5">
+
+    <div class="breadcrumbs">root
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources" onclick="anchorLink('sources')">sources</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties" onclick="anchorLink('sources_additionalProperties')">additionalProperties</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf" onclick="anchorLink('sources_additionalProperties_oneOf')">oneOf</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12" onclick="anchorLink('sources_additionalProperties_oneOf_i12')">GitHub Actions</a>
+        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-arrow-right-short" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path
+                fill-rule="evenodd"
+                d="M4 8a.5.5 0 0 1 .5-.5h5.793L8.146 5.354a.5.5 0 1 1 .708-.708l3 3a.5.5 0 0 1 0 .708l-3 3a.5.5 0 0 1-.708-.708L10.293 8.5H4.5A.5.5 0 0 1 4 8z"
+            />
+        </svg>
+    <a href="#sources_additionalProperties_oneOf_i12_type" onclick="anchorLink('sources_additionalProperties_oneOf_i12_type')">type</a></div><span class="badge badge-dark value-type">Type: const</span><br/>
+<span class="const-value" id="sources_additionalProperties_oneOf_i12_type_const">Specific value: <code>"githubactions"</code></span>
         
 
         


### PR DESCRIPTION
## Summary

- Adds PVC-based persistence for the scrypt hash cache so it survives across CronJob runs
- Only the inventory CronJob gets the cache mount (ping/sync don't hash)
- Adds `persistence` section to `values.yaml`, `values.schema.json`, and templates
- Includes 11 helm-unittest test cases covering PVC creation, env var injection, volumeMount, existingClaim, and disabled state

## Changes

| File | What |
|------|------|
| `values.yaml` | New `persistence` block: `enabled`, `storageClassName`, `size`, `existingClaim` |
| `values.schema.json` | Schema definition for IDE completion + validation |
| `templates/persistentvolumeclaim.yaml` | Creates PVC when `persistence.enabled && !existingClaim` |
| `templates/_cronjob.tpl` | Conditionally injects `HASH_CACHE_PATH` env, volumeMount, and PVC volume |
| `templates/cronjob_inventory.yaml` | Passes `use_cache_pvc: true` to shared template |
| `tests/persistence_test.yaml` | 11 test cases across 2 suites |
| `Chart.yaml` | Version bump 0.5.14 → 0.5.15 |

## Usage

```yaml
persistence:
  enabled: true          # creates PVC, mounts it, sets HASH_CACHE_PATH
  # storageClassName: "" # optional, defaults to cluster default
  # size: 100Mi          # optional, 64 bytes/entry → 100Mi handles ~1.6M secrets
  # existingClaim: ""    # optional, use pre-existing PVC instead of creating one
```

Without `persistence.enabled`, behavior is unchanged — secrets are hashed from scratch every run.

## Test plan

- [x] `helm unittest charts/ggscout` — all 40 tests pass (11 new persistence tests)
- [x] `helm template` renders correctly with and without persistence
- [x] Deployed to eks-sandbox-01 with `persistence.enabled: true` — cold run: 0 hits/40 misses, warm run: 40 hits/0 misses

In eks-sandbox-01:

<img width="1434" height="213" alt="Screenshot 2026-03-06 at 15 22 47" src="https://github.com/user-attachments/assets/1f7462b2-ffde-4bbe-8dff-5f72633034a3" />
<img width="1428" height="213" alt="Screenshot 2026-03-06 at 15 23 17" src="https://github.com/user-attachments/assets/be3abad9-2f5c-469a-818d-93f85e0c3f56" />
